### PR TITLE
Fixing the Guides and Docs link

### DIFF
--- a/dgs_theme/partials/header.html
+++ b/dgs_theme/partials/header.html
@@ -67,7 +67,7 @@
     </div>
 
     <div class="dgs-header-nav__start">
-      <a class="md-header-nav__button dgs-header-nav__button dgs-getting-started" href="getting-started/">
+      <a class="md-header-nav__button dgs-header-nav__button dgs-getting-started" href="/dgs/getting-started/">
         <span class="dgs-header-nav__text--upper">Guides & Docs</span>
         <span class="dgs-header-nav__text--lower">
           <time>Updated {{ build_date_utc.strftime('%Y-%m-%d') }}</time>


### PR DESCRIPTION
Changing the `Guides & Docs` link to be _absolute_ due that is broken when rendered from a side that is not relative to root.
Example of these elements include all of the below.
![image](https://user-images.githubusercontent.com/134985/104232858-c749bc00-5405-11eb-934d-586732f005bd.png)
