### PR TITLE
toggleable color scheme preference

### DIFF
--- a/dgs_theme/partials/header.html
+++ b/dgs_theme/partials/header.html
@@ -82,6 +82,34 @@
       </div>
     {% endif %}
 
+     <!-- Color palette -->
+    {% if not config.theme.palette is mapping %}
+      <form class="md-header__option" data-md-component="palette">
+        {% for option in config.theme.palette %}
+          {% set primary = option.primary | replace(" ", "-") | lower %}
+          {% set accent  = option.accent  | replace(" ", "-") | lower %}
+          <input
+            class="md-option"
+            data-md-color-media="{{ option.media }}"
+            data-md-color-scheme="{{ option.scheme }}"
+            data-md-color-primary="{{ primary }}"
+            data-md-color-accent="{{ accent }}"
+            type="radio"
+            name="__palette"
+            id="__palette_{{ loop.index }}"
+          />
+          <label
+            class="md-header__button md-icon"
+            title="{{ option.toggle.name }}"
+            for="__palette_{{ loop.index0 or loop.length }}"
+            hidden
+          >
+            {% include ".icons/" ~ option.toggle.icon ~ ".svg" %}
+          </label>
+        {% endfor %}
+      </form>
+    {% endif %}
+
     <!-- Button to open drawer -->
     <label class="md-header-nav__button md-icon dgs-header-nav__button" for="__drawer">
       {% include ".icons/material/menu" ~ ".svg" %}

--- a/docs/stylesheets/dgs_theme.css
+++ b/docs/stylesheets/dgs_theme.css
@@ -78,7 +78,7 @@
   --transition-timing: 125ms;
 }
 
-html {
+body {
   --background-color: var(--background-color--dark);
   --background-color__accent: var(--background-color__accent--dark);
   --background-color__accent--heavy: var(--background-color__accent--heavy--dark);
@@ -111,7 +111,7 @@ html {
   --text-color--reverse: var(--text-color--reverse--dark);
 }
 
-html.theme--light {
+body[data-md-color-scheme="default"] {
   --background-color: var(--background-color--light);
   --background-color__accent: var(--background-color__accent--light);
   --background-color__accent--heavy: var(--background-color__accent--heavy--light);
@@ -145,7 +145,7 @@ html.theme--light {
 }
 
 @media (prefers-color-scheme: light) {
-  html {
+  body {
     --background-color: var(--background-color--light);
     --background-color__accent: var(--background-color__accent--light);
     --background-color__accent--heavy: var(--background-color__accent--heavy--light);
@@ -178,7 +178,7 @@ html.theme--light {
     --text-color--reverse: var(--text-color--reverse--light);
   }
 
-  html.theme--dark {
+  body[data-md-color-scheme="slate"] {
     --background-color: var(--background-color--dark);
     --background-color__accent: var(--background-color__accent--dark);
     --background-color__accent--heavy: var(--background-color__accent--heavy--dark);
@@ -365,7 +365,6 @@ body {
   font-weight: bold;
 }
 .dgs-header-nav__button[for="__drawer"] {
-  padding-left: 1.5rem;
   padding-right: 1.5rem;
 }
 
@@ -384,6 +383,9 @@ body {
 @media screen and (min-width: 76.25em) {
   .md-header-nav__button[for=__drawer] {
     display: none;
+  }
+  form.md-header__option {
+    padding-right: 1rem;
   }
 }
 
@@ -436,7 +438,7 @@ body {
 }
 .dgs-header-nav__source {
   max-width: none;
-  padding-right: 2rem;
+  padding-right: 1.5rem;
   width: auto;
 }
 
@@ -607,6 +609,9 @@ body {
 
 .md-icon svg {
   fill: var(--text-color);
+}
+.md-header__button.md-icon svg {
+  fill: var(--header-link__color);
 }
 .md-search__input~.md-search__icon svg {
   fill: var(--input__placeholder-color--dark);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,12 +38,30 @@ extra_javascript:
 theme:
   name: material
   palette:
-    scheme: preference
+    # Light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+      accent: light green
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+
+    # Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue
+      accent: light green
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
   custom_dir: dgs_theme
   favicon: images/favicon.png
   logo: images/logo--blue.svg
   icon:
     repo: octicons/mark-github-16
+
+
 markdown_extensions:
   - pymdownx.highlight:
       linenums: true


### PR DESCRIPTION
Updated styling to work with `mkdocs-material` 7.1.0, which altered the defaults around `scheme: preference` but introduced user-toggle-able color schemes (previously an insiders-only feature)