### PR TITLE
Documenting Configuration Options.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,26 @@
+
+## Configure the location of the GraphQL Schema Files
+
+You can configure the location of your GraphQL schema files via the `dgs.graphql.schema-locations` property.
+By default it will attempt to load them from the `schema` directory via the _Classpath_, i.e. using `classpath*:schema/**/*.graphql*`.
+Let's go through an example, let's say you want to change the directory from being `schema` to `graphql-schemas`,
+you would define your configuration as follows:
+
+```yaml
+dgs:
+    graphql:
+        schema-locations:
+            - classpath*:graphql-schemas/**/*.graphql*
+```
+
+Now, if you want to add additional locations to look for the GraphQL Schema files you an add them to the list.
+For example, let's say we want to also look into your `graphql-experimental-schemas`:
+
+```yaml
+dgs:
+    graphql:
+        schema-locations:
+            - classpath*:graphql-schemas/**/*.graphql*
+            - classpath*:graphql-experimental-schemas/**/*.graphql*
+```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ repo_url: https://github.com/netflix/dgs-framework
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Configuration: configuration.md
   - Data fetching: datafetching.md
   - Testing: query-execution-testing.md
   - Mutations: mutations.md


### PR DESCRIPTION
Adding a top level section to host Configuration Options. For now it
only explains how to configure the schema-location.