### PR TITLE
Document SB Gradle Plugin 2.3.x Kotlin caveats.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,9 +46,23 @@ dgs version:
     </dependency>
     ```
 
-<div style="padding: 15px; border: 1px solid transparent; border-color: transparent; margin-bottom: 20px; border-radius: 4px; color: #8a6d3b;; background-color: #fcf8e3; border-color: #faebcc;">
- NOTE: The DGS Framework requires Kotlin 1.4, and does not work with Kotlin 1.3. Older Spring Boot versions may bring in Kotlin 1.3.
-</div>
+!!! caution
+    The DGS Framework requires Kotlin 1.4, and does not work with Kotlin 1.3. Older Spring Boot versions may bring in Kotlin 1.3.
+
+!!! important
+    If you use [Spring Boot Gradle Plugin 2.3], you will have to be explicit on the Kotlin version that
+    will be available. **This plugin will downgrade the transitive 1.4 Kotlin version to 1.3**.
+    You can be explicit by setting it via Gradle's _extensions_ as follows:
+    === "Gradle"
+        ```groovy
+        ext['slf4j.version'] = '1.4.31'
+        ```
+    === "Gradle Kotlin"
+        ```kotlin
+        extra["kotlin.version"] = "1.4.31"
+        ```
+
+[Spring Boot Gradle Plugin 2.3]: https://docs.spring.io/spring-boot/docs/2.3.10.RELEASE/gradle-plugin/reference/html/
 
 ## Creating a Schema
 


### PR DESCRIPTION
Context
======

Even thought the DGS Framework provides the proper transitive version for Kotlin, see data below, the [Spring Boot Gradle Plugin 2.3] will downgrade the version to 1.3. Developers will have to explicitly set it via Gradle's _extensions_.

[Spring Boot Gradle Plugin 2.3]: https://docs.spring.io/spring-boot/docs/2.3.10.RELEASE/gradle-plugin/reference/html/

DGS Artifact Metadata for Kotlin
========================

Gradle metadata

```
{
          "group": "org.jetbrains.kotlin",
          "module": "kotlin-stdlib-jdk8",
          "version": {
            "requires": "1.4.32"
          }
}
```

Maven POM

```
<dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-stdlib-jdk8</artifactId>
      <version>1.4.32</version>
      <scope>compile</scope>
</dependency>
```

Ref https://github.com/Netflix/dgs-examples-java/pull/19

Snapshot
=======

Note the *Important* block below:

![image](https://user-images.githubusercontent.com/134985/117393731-9bb57a80-aea9-11eb-8204-74ff5db0c369.png)
