### PR TITLE
Adding Permanent Links to TOC items.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,13 +65,15 @@ theme:
 
 
 markdown_extensions:
+  - admonition
   - pymdownx.highlight:
       linenums: true
       linenums_style: pymdownx-inline
   - pymdownx.superfences
   - pymdownx.inlinehilite
   - pymdownx.tabbed
-  - admonition
   - pymdownx.details
   - pymdownx.superfences
+  - toc:
+      permalink: True
   - footnotes


### PR DESCRIPTION
Via the tock-permalink plugin this commit enables links for TOC elements to facilitate sharing links.