### PR TITLE
Improve the example of Scalars in DGS Client

### DIFF
--- a/docs/advanced/java-client.md
+++ b/docs/advanced/java-client.md
@@ -192,22 +192,20 @@ Note that the `edges` and `node` fields are because the example schema is using 
 
 ### Scalars in DGS Client
 
-Custom scalars can be used in input types in GraphQL. Let's take the example of a `DateRange` scalar that represents a "from" and "to" date.
-In Java, we want to represent this as a DateRange class that takes a `LocalDate` for the `from` and `to` fields.
-When generating a query API we want to be use the API as follows:
+Custom scalars can be used in input types in GraphQL. Let's take the example of a `DateTimeScalar` (created in [Adding Custom Scalars](../scalars.md)). In Java, we want to represent this as a `LocalDateTime` class. When sending the query, we somehow have to serialize this. There are many ways to represent a date, so how do we make sure that we use the same representation as the server expects?
+
+In this release we added an optional `scalars` argument to the `GraphQLQueryRequest` constructor. This is a `Map<Class<?>, Coercing<?,?>>` that maps the Java class representing the input to an actual Scalar implementation. We will generate the query API with `DateTimeScalar` as follows:
 
 ```java
+Map<Class<?>, Coercing<?, ?>> scalars = new HashMap<>();
+scalars.put(java.time.LocalDateTime.class, new DateTimeScalar());
+
 new GraphQLQueryRequest(
                 ReviewsGraphQLQuery.newRequest().dateRange(new DateRange(LocalDate.of(2020, 1, 1), LocalDate.now())).build(),
                 new ReviewsProjectionRoot().submittedDate().starScore(), scalars);
 ```
 
-When sending the query, we somehow have to serialize this `DateRange` though.
-There are many ways to represent a date, so how do we make sure that we use the same representation as the server expects?
-
-In this release we added an optional `scalars` argument to the `GraphQLQueryRequest` constructor.
-This is a `Map<Class<?>, Coercing<?,?>` that maps the Java class representing the input to an actual Scalar implementation.
-This way you can re-use exactly the same serialization code that you already have for your scalar implementation or one of the existing ones from for example the `graphql-dgs-extended-scalars` module.
+This way you can re-use exactly the same serialization code that you already have for your scalar implementation or one of the existing ones from - for example - the `graphql-dgs-extended-scalars` module.
 
 ### Interface projections
 

--- a/docs/advanced/java-client.md
+++ b/docs/advanced/java-client.md
@@ -196,7 +196,7 @@ Custom scalars can be used in input types in GraphQL. Let's take the example of 
 In Java, we want to represent this as a DateRange class that takes a `LocalDate` for the `from` and `to` fields.
 When generating a query API we want to be use the API as follows:
 
-```
+```java
 new GraphQLQueryRequest(
                 ReviewsGraphQLQuery.newRequest().dateRange(new DateRange(LocalDate.of(2020, 1, 1), LocalDate.now())).build(),
                 new ReviewsProjectionRoot().submittedDate().starScore(), scalars);

--- a/docs/scalars.md
+++ b/docs/scalars.md
@@ -38,6 +38,13 @@ public class DateTimeScalar implements Coercing<LocalDateTime, String> {
 scalar DateTime
 ```
 
+
+!!! important
+    If you are [Building GraphQL Queries for Tests](./query-execution-testing.md), make sure to pass your custom scalars in
+    `GraphQLQueryRequest` constructor as descibred in [Scalars in DGS Client](./advanced/java-client.md)
+
+
+
 ## Registering Custom Scalars
 
 In more recent versions of `graphql-java` (>v15.0) [some scalars](https://github.com/graphql-java/graphql-java-extended-scalars),


### PR DESCRIPTION
The suggested improvements come from my personal usage. The first time I had to use custom scalars in testing, I faced a few problems in understanding the correct usage. These changes will help with the following:

1. In `Scalars in DGS Client`, continue the example of `Adding Custom Scalars` instead of creating a new one to avoid any sort of confusions and *complete* the original example.
2. Provide complete code for initializing and using `Map<Class<?>, Coercing<?,?>>` which can be difficult for new programmers (as myself).
3. Link the instructions of Client API in `Adding Custom Scalars` so that these are not missed by anyone. Generally, people will start from here and come back to this page when the problem occurs. So, the solution must be linked from this page.