### PR TITLE
(docs) Add graphql-dgs-extended-validation configuration section

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,18 +1,15 @@
-
 ## Configuration
-
 
 ### Core Properties
 
-| Name                            | Type         | Default                              |  Description |
-| ------------------------------- | ------------ | ------------------------------------ | ------------ |
-| dgs.graphql.path                | String       | `"/graphql"`                         | Path to the endpoint that will serve GraphQL requests.   |
-| dgs.graphql.schema-json.enabled | Boolean      | `true`                               | Enables schema-json endpoint functionality. |
-| dgs.graphql.schema-json.path    | String       | `"/schema.json"`                     | Path to the schema-json endpoint without trailing slash. |
-| dgs.graphql.schema-locations    | [String]     | `"classpath*:schema/**/*.graphql*"`  | Location of the GraphQL schema files.                    |
-| dgs.graphql.graphiql.enabled    | Boolean      | `true`                               | Enables GraphiQL functionality. |
-| dgs.graphql.graphiql.path       | String       | `"/graphiql"`                        | Path to the GraphiQL endpoint without trailing slash. |
-
+| Name                            | Type     | Default                             | Description                                              |
+| ------------------------------- | -------- | ----------------------------------- | -------------------------------------------------------- |
+| dgs.graphql.path                | String   | `"/graphql"`                        | Path to the endpoint that will serve GraphQL requests.   |
+| dgs.graphql.schema-json.enabled | Boolean  | `true`                              | Enables schema-json endpoint functionality.              |
+| dgs.graphql.schema-json.path    | String   | `"/schema.json"`                    | Path to the schema-json endpoint without trailing slash. |
+| dgs.graphql.schema-locations    | [String] | `"classpath*:schema/**/*.graphql*"` | Location of the GraphQL schema files.                    |
+| dgs.graphql.graphiql.enabled    | Boolean  | `true`                              | Enables GraphiQL functionality.                          |
+| dgs.graphql.graphiql.path       | String   | `"/graphiql"`                       | Path to the GraphiQL endpoint without trailing slash.    |
 
 #### Example: Configure the location of the GraphQL Schema Files
 
@@ -23,9 +20,9 @@ you would define your configuration as follows:
 
 ```yaml
 dgs:
-    graphql:
-        schema-locations:
-            - classpath*:graphql-schemas/**/*.graphql*
+  graphql:
+    schema-locations:
+      - classpath*:graphql-schemas/**/*.graphql*
 ```
 
 Now, if you want to add additional locations to look for the GraphQL Schema files you an add them to the list.
@@ -33,46 +30,46 @@ For example, let's say we want to also look into your `graphql-experimental-sche
 
 ```yaml
 dgs:
-    graphql:
-        schema-locations:
-            - classpath*:graphql-schemas/**/*.graphql*
-            - classpath*:graphql-experimental-schemas/**/*.graphql*
+  graphql:
+    schema-locations:
+      - classpath*:graphql-schemas/**/*.graphql*
+      - classpath*:graphql-experimental-schemas/**/*.graphql*
 ```
-
-
-
 
 ### DGS Extended Scalars: graphql-dgs-extended-scalars
 
-| Name                                              | Type    | Default  |  Description |
-| ------------------------------------------------- | --------| -------- | ------------ |
-| dgs.graphql.extensions.scalars.enabled            | Boolean | `true`   | Registered the Scalar Extensions available in graphql-java-extended-scalars for the DGS Framework. |
-| dgs.graphql.extensions.scalars.chars.enabled      | Boolean | `true`   | Will register the GraphQLChar extension. |
-| dgs.graphql.extensions.scalars.numbers.enabled    | Boolean | `true`   | Will register all numeric scalar extensions such as PositiveInt, NegativeInt, etc. |
-| dgs.graphql.extensions.scalars.objects.enabled    | Boolean | `true`   | Will register the Object, Json, Url, and Locale scalar extensions. |
-| dgs.graphql.extensions.scalars.time-dates.enabled | Boolean | `true`   | Will register the DateTime, Date, and Time scalar extensions. |
+| Name                                              | Type    | Default | Description                                                                                                                                                         |
+| ------------------------------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| dgs.graphql.extensions.scalars.enabled            | Boolean | `true`  | Registered the Scalar Extensions available in [graphql-java-extended-scalars](https://github.com/graphql-java/graphql-java-extended-scalars) for the DGS Framework. |
+| dgs.graphql.extensions.scalars.chars.enabled      | Boolean | `true`  | Will register the GraphQLChar extension.                                                                                                                            |
+| dgs.graphql.extensions.scalars.numbers.enabled    | Boolean | `true`  | Will register all numeric scalar extensions such as PositiveInt, NegativeInt, etc.                                                                                  |
+| dgs.graphql.extensions.scalars.objects.enabled    | Boolean | `true`  | Will register the Object, Json, Url, and Locale scalar extensions.                                                                                                  |
+| dgs.graphql.extensions.scalars.time-dates.enabled | Boolean | `true`  | Will register the DateTime, Date, and Time scalar extensions.                                                                                                       |
 
+### DGS Extended Validation: graphql-dgs-extended-validation
+
+| Name                                      | Type    | Default | Description                                                                                                                                                                                    |
+| ----------------------------------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| dgs.graphql.extensions.validation.enabled | Boolean | `true`  | Registered the Validation Schema Directive Extensions available in [graphql-java-extended-validation](https://github.com/graphql-java/graphql-java-extended-validation) for the DGS Framework. |
 
 ### DGS Metrics: graphql-dgs-spring-boot-micrometer
 
-
-| Name                                                                   | Type     | Default  |  Description |
-| ---------------------------------------------------------------------- | -------- | -------- | ------------ |
-| management.metrics.dgs-graphql.enabled                                 | Boolean  | `true`   | Enables DGS' GraphQL metrics, via micrometer. |
-| management.metrics.dgs-graphql.instrumentation.enabled                 | Boolean  | `true`   | Enables DGS' GraphQL's base instrumentation; emits `gql.query`, `gql.resolver`, and `gql.error` meters. |
-| management.metrics.dgs-graphql.data-loader-instrumentation.enabled     | Boolean  | `true`   | Enables DGS' instrumentation for DataLoader; emits `gql.dataLoader` meters. |
-| management.metrics.dgs-graphql.tag-customizers.outcome.enabled         | Boolean  | `true`   | Enables DGS' GraphQL Outcome tag customizer. This adds an OUTCOME tag that is ether SUCCESS or ERROR to the emitted gql meters. |
-| management.metrics.dgs-graphql.query-signature.enabled                 | Boolean  | `true`   | Enables DGS' `QuerySignatureRepository`; if available metrics will be tagged with the `gql.query.sig.hash`.
-| management.metrics.dgs-graphql.query-signature.caching.enabled         | Boolean  | `true`   | Enables DGS' `QuerySignature` caching; if set to false the signature will always be calculated on each request. |
-| management.metrics.dgs-graphql.tags.limiter.limit                      | Integer  | 100      | The limit that will apply for this tag. The interpretation of this limit depends on the cardinality limiter itself. |
-| management.metrics.dgs-graphql.autotime.percentiles                    | [Double] | []       | DGS Micrometer Timers percentiles, e.g. `[0.95, 0.99, 0.50]`. [^1]|
-| management.metrics.dgs-graphql.autotime.percentiles-histogram          | Boolean  | `false`  | Enables publishing percentile histograms for the DGS Micrometer Timers. [^1]|
-
+| Name                                                               | Type     | Default | Description                                                                                                                     |
+| ------------------------------------------------------------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| management.metrics.dgs-graphql.enabled                             | Boolean  | `true`  | Enables DGS' GraphQL metrics, via micrometer.                                                                                   |
+| management.metrics.dgs-graphql.instrumentation.enabled             | Boolean  | `true`  | Enables DGS' GraphQL's base instrumentation; emits `gql.query`, `gql.resolver`, and `gql.error` meters.                         |
+| management.metrics.dgs-graphql.data-loader-instrumentation.enabled | Boolean  | `true`  | Enables DGS' instrumentation for DataLoader; emits `gql.dataLoader` meters.                                                     |
+| management.metrics.dgs-graphql.tag-customizers.outcome.enabled     | Boolean  | `true`  | Enables DGS' GraphQL Outcome tag customizer. This adds an OUTCOME tag that is ether SUCCESS or ERROR to the emitted gql meters. |
+| management.metrics.dgs-graphql.query-signature.enabled             | Boolean  | `true`  | Enables DGS' `QuerySignatureRepository`; if available metrics will be tagged with the `gql.query.sig.hash`.                     |
+| management.metrics.dgs-graphql.query-signature.caching.enabled     | Boolean  | `true`  | Enables DGS' `QuerySignature` caching; if set to false the signature will always be calculated on each request.                 |
+| management.metrics.dgs-graphql.tags.limiter.limit                  | Integer  | 100     | The limit that will apply for this tag. The interpretation of this limit depends on the cardinality limiter itself.             |
+| management.metrics.dgs-graphql.autotime.percentiles                | [Double] | []      | DGS Micrometer Timers percentiles, e.g. `[0.95, 0.99, 0.50]`. [^1]                                                              |
+| management.metrics.dgs-graphql.autotime.percentiles-histogram      | Boolean  | `false` | Enables publishing percentile histograms for the DGS Micrometer Timers. [^1]                                                    |
 
 !!!hint
-    You can configure percentiles, and enable percentile histograms, directly via the per-meter customizations available
-    out of the box in Spring Boot. For example, to enable percentile histograms for all `gql.*` meters you can
-    set the following property:
+You can configure percentiles, and enable percentile histograms, directly via the per-meter customizations available
+out of the box in Spring Boot. For example, to enable percentile histograms for all `gql.*` meters you can
+set the following property:
 
     ```
     management.metrics.distribution.percentiles-histogram.gql=true
@@ -80,7 +77,6 @@ dgs:
 
     For more information please refer to [Spring Boot's Per Meter Properties].
 
-
 [^1]: [Spring Boot's Per Meter Properties] can be used to configure percentiles, and histograms, out of the box.
 
-[Spring Boot's Per Meter Properties]: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#actuator.metrics.customizing.per-meter-properties
+[spring boot's per meter properties]: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#actuator.metrics.customizing.per-meter-properties


### PR DESCRIPTION
[dgs-framework v4.9.10](https://github.com/Netflix/dgs-framework/releases/tag/v4.9.10) introduced support for `graphql-java-extended-validation`

Adding an entry in the configuration docs page for this new extension