### PR TITLE
Rename "Async Data Fetching" section to "Data Loaders (N+1)"

### DIFF
--- a/docs/data-loaders.md
+++ b/docs/data-loaders.md
@@ -1,4 +1,4 @@
-Data loaders solve the N+1 problem while loading data.
+Data loaders solve the [N+1 problem](https://stackoverflow.com/q/97197/8237967) while loading data.
 
 ## The N+1 Problem Explained
 Say you query for a list of movies, and each movie includes some data about the director of the movie.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,7 @@ nav:
   - Testing: query-execution-testing.md
   - Mutations: mutations.md
   - Code Generation: generating-code-from-schema.md
-  - Async Data Fetching: data-loaders.md
+  - Data Loaders (N+1): data-loaders.md
   - Error Handling: error-handling.md
   - Federation: federation.md
   - Examples: examples.md


### PR DESCRIPTION
This was seriously bothering me every time I am sending the documentation to someone.

Also added clarification on what N+1 is by linking the top SO question (no Wikipedia article as far as I can find).

![Screenshot of resulting documentation](https://user-images.githubusercontent.com/30464310/156655903-0179d06c-98a9-4da8-8cdc-ff7f5bf573ab.png)
