### PR TITLE
Add documentation around thread pool / executor optimization 

### DIFF
--- a/docs/data-loaders.md
+++ b/docs/data-loaders.md
@@ -211,13 +211,13 @@ public CompletableFuture<List<Thing>> resolve(DataFetchingEnvironment environmen
 
 ## Thread Pool Optimization
 
-Using `supplyAsync()` without a second argument provided causes the main work of a Data loader to run on a [common thread pool](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ForkJoinPool.html#commonPool--) 
-shared with most other async operations in your application. If that Data loader is calling a slow service and subject to heavy load, the common thread pool could become fully saturated.
+Using `supplyAsync()` without a second argument will cause the main work of a Data loader to run on a [common thread pool](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ForkJoinPool.html#commonPool--) 
+shared with most other async operations in your application. If that Data loader is responsible for calling a slow service and/or subject to heavy load, the common thread pool could become fully saturated.
 In the worst case, this could result in application "freezes" as each dataloader in the application awaits a free thread from the fixed-size common pool. 
 
-To account for this, IO-bound Data loaders should instead maintain their own dedicated thread pool rather than reserve threads from the common pool. 
+To account for this, IO-bound Data loaders should instead maintain their own dedicated thread pool rather than use the common pool.
 When choosing a thread pool, it's recommended to review the options under the [Executors Javadoc](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html),
-but a safe default for IO bound workloads is usually `Executors.newCachedThreadPool()`. As opposed to the fixed-size static thread pool, `Executors.newCachedThreadPool` will 
+but a safe default for IO bound workloads is usually `Executors.newCachedThreadPool()`. As opposed to the fixed-size static thread pool, `Executors.newCachedThreadPool()` will 
 create new threads on-demand if all previously-createds threads are saturated.
 
 ```java

--- a/docs/data-loaders.md
+++ b/docs/data-loaders.md
@@ -218,7 +218,7 @@ In the worst case, this could result in application "freezes" as each data loade
 To account for this, IO-bound data loaders should instead maintain their own dedicated thread pool rather than use the common pool.
 When choosing a thread pool, it's recommended to review the options under the [Executors Javadoc](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html),
 but a safe default for IO bound workloads is usually `Executors.newCachedThreadPool()`. As opposed to the fixed-size common thread pool, `Executors.newCachedThreadPool()` will 
-create new threads on-demand if all previously-createds threads are saturated, but still prefers thread re-use when possible.
+create new threads on-demand if all previously-created threads are saturated but still prefers thread re-use when possible.
 
 ```java
 @Configuration

--- a/docs/data-loaders.md
+++ b/docs/data-loaders.md
@@ -217,7 +217,7 @@ In the worst case, this could result in application "freezes" as each data loade
 
 To account for this, IO-bound data loaders should instead maintain their own dedicated thread pool rather than use the common pool.
 When choosing a thread pool, it's recommended to review the options under the [Executors Javadoc](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html),
-but a safe default for IO bound workloads is usually `Executors.newCachedThreadPool()`. As opposed to the fixed-size static thread pool, `Executors.newCachedThreadPool()` will 
+but a safe default for IO bound workloads is usually `Executors.newCachedThreadPool()`. As opposed to the fixed-size common thread pool, `Executors.newCachedThreadPool()` will 
 create new threads on-demand if all previously-createds threads are saturated, but still prefers thread re-use when possible.
 
 ```java

--- a/docs/data-loaders.md
+++ b/docs/data-loaders.md
@@ -218,7 +218,7 @@ In the worst case, this could result in application "freezes" as each data loade
 To account for this, IO-bound data loaders should instead maintain their own dedicated thread pool rather than use the common pool.
 When choosing a thread pool, it's recommended to review the options under the [Executors Javadoc](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html),
 but a safe default for IO bound workloads is usually `Executors.newCachedThreadPool()`. As opposed to the fixed-size common thread pool, `Executors.newCachedThreadPool()` will 
-create new threads on-demand if all previously-created threads are saturated but still prefers thread re-use when possible.
+create new threads on-demand if all previously-created threads are saturated, but still prefers thread re-use when possible.
 
 ```java
 @Configuration


### PR DESCRIPTION
Hey folks! Let me know if there's a better forum/process for pursuing documentation updates -- I'm also super open to feedback on format / wording / content if there are any changes you'd like to see in the provided section.

## Background

My team operates a service powered by DGS, and we recently ran into a thread pooling issue that boiled down to the expansive use of `supplyAsync(1)` in our data loaders. During heavy load (compounded with a performance degradation in a downstream service), we saw that our common thread pool often became blocked as those slow loader operations reserved time from a relatively small number of worker threads. 

This PR adds a section on thread pool optimization with a possible solution (that we pursued), that advocates/explains why `supplyAsync(1)` without a dedicated executor could be dangerous. 

Short of the use case for security context, executor choice isn't mentioned anywhere else in the documentation -- so I'm hoping this is an uncontroversial addition!

Thanks in advance for the consideration on this PR -- and thank you for DGS in general :)