### PR TITLE
Update docs for client API v2

### DIFF
--- a/docs/advanced/federated-testing.md
+++ b/docs/advanced/federated-testing.md
@@ -90,7 +90,7 @@ This set up is shown here:
         // sets up the query and the field selection set using the EntitiesProjectionRoot
         GraphQLQueryRequest request = new GraphQLQueryRequest(
                     entitiesQuery,
-                    new EntitiesProjectionRoot().onMovie().movieId().script().title());
+                    new EntitiesProjectionRoot<>().onMovie().movieId().script().title());
 
         String query  = request.serialize();
         // pass in the constructed _entities query with the variable map containing representations

--- a/docs/advanced/java-client.md
+++ b/docs/advanced/java-client.md
@@ -195,10 +195,10 @@ We plan to eventually remove the `DefaultGraphQLClient`, because its API is conf
 
 ## Type safe Query API
 
-Based on a GraphQL schema a type safe query API can be generated for Java/Kotlin.
-The generated API is a builder style API that lets you build a GraphQL query, and it's projection (field selection).
+A type safe query API based on a GraphQL schema can be generated for Java/Kotlin.
+The generated API is a builder style API that lets you build a GraphQL query and its projection (field selection).
 Because the code gets re-generated when the schema changes, it helps catch errors in the query.
-It's arguably also more readable, although multiline String support in Java and Kotlin do mitigate that issue as well.
+It's arguably also more readable, although multiline String support in Java and Kotlin does mitigate that issue as well.
 
 If you own a DGS and want to generate a client for this DGS (e.g. for testing purposes) the client generation is just an extra property on the [Codegen configuration](../generating-code-from-schema.md).
 Specify the following in your `build.gradle`.
@@ -211,7 +211,7 @@ plugins {
 
 generateJava{
    packageName = 'com.example.packagename' // The package name to use to generate sources
-   generateClient = true
+   generateClientv2 = true
 }
 ```
 
@@ -227,7 +227,7 @@ GraphQLQueryRequest graphQLQueryRequest =
                         .first(first)
                         .after(after)
                         .build(),
-                    new TicksConnectionProjectionRoot()
+                    new TicksConnectionProjectionRoot<>()
                         .edges()
                             .node()
                                 .date()
@@ -263,7 +263,7 @@ scalars.put(java.time.LocalDateTime.class, new DateTimeScalar());
 
 new GraphQLQueryRequest(
                 ReviewsGraphQLQuery.newRequest().dateRange(new DateRange(LocalDate.of(2020, 1, 1), LocalDate.now())).build(),
-                new ReviewsProjectionRoot().submittedDate().starScore(), scalars);
+                new ReviewsProjectionRoot<>().submittedDate().starScore(), scalars);
 ```
 
 This way you can re-use exactly the same serialization code that you already have for your scalar implementation or one of the existing ones from - for example -
@@ -316,7 +316,7 @@ This syntax is supported by the Query builder as well.
         new ScriptGraphQLQuery.Builder()
             .name("Top Secret")
             .build(),
-        new ScriptProjectionRoot()
+        new ScriptProjectionRoot<>()
             .title()
             .onMovieScript()
                 .length();
@@ -365,7 +365,7 @@ Here is an example for the schema shown earlier:
                     .build();
         GraphQLQueryRequest request = new GraphQLQueryRequest(
                     entitiesQuery,
-                    new EntitiesProjectionRoot().onMovie().movieId().script().title()
+                    new EntitiesProjectionRoot<>().onMovie().movieId().script().title()
                     );
 
         String query  = request.serialize();

--- a/docs/advanced/subscriptions.md
+++ b/docs/advanced/subscriptions.md
@@ -149,17 +149,17 @@ public class ReviewSubscriptionIntegrationTest {
     public void testWebSocketSubscription() {
         GraphQLQueryRequest subscriptionRequest = new GraphQLQueryRequest(
                 ReviewAddedGraphQLQuery.newRequest().showId(1).build(),
-                new ReviewAddedProjectionRoot().starScore()
+                new ReviewAddedProjectionRoot<>().starScore()
         );
 
         GraphQLQueryRequest addReviewMutation1 = new GraphQLQueryRequest(
                 AddReviewGraphQLQuery.newRequest().review(SubmittedReview.newBuilder().showId(1).starScore(5).username("DGS User").build()).build(),
-                new AddReviewProjectionRoot().starScore()
+                new AddReviewProjectionRoot<>().starScore()
         );
 
         GraphQLQueryRequest addReviewMutation2 = new GraphQLQueryRequest(
                 AddReviewGraphQLQuery.newRequest().review(SubmittedReview.newBuilder().showId(1).starScore(3).username("DGS User").build()).build(),
-                new AddReviewProjectionRoot().starScore()
+                new AddReviewProjectionRoot<>().starScore()
         );
 
         Flux<Integer> starScore = webSocketGraphQLClient.reactiveExecuteQuery(subscriptionRequest.serialize(), Collections.emptyMap()).map(r -> r.extractValue("reviewAdded.starScore"));

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -226,7 +226,7 @@ class ReviewssDatafetcherTest {
     @Test
     void showsWithEntitiesQueryBuilder() {
         EntitiesGraphQLQuery entitiesQuery = new EntitiesGraphQLQuery.Builder().addRepresentationAsVariable(ShowRepresentation.newBuilder().id("1").build()).build();
-        GraphQLQueryRequest request = new GraphQLQueryRequest(entitiesQuery, new EntitiesProjectionRoot().onShow().reviews().starRating());
+        GraphQLQueryRequest request = new GraphQLQueryRequest(entitiesQuery, new EntitiesProjectionRoot<>().onShow().reviews().starRating());
         List<Review> reviewsList = dgsQueryExecutor.executeAndExtractJsonPathAsObject(
                 request.serialize(),
                 "data['_entities'][0].reviews", entitiesQuery.getVariables(), new TypeRef<>() {

--- a/docs/query-execution-testing.md
+++ b/docs/query-execution-testing.md
@@ -124,7 +124,7 @@ Now we can write a test that uses `GraphQLQueryRequest` to build the query and e
     public void showsWithQueryApi() {
         GraphQLQueryRequest graphQLQueryRequest = new GraphQLQueryRequest(
                 new ShowsGraphQLQuery.Builder().titleFilter("Oz").build(),
-                new ShowsProjectionRoot().title()
+                new ShowsProjectionRoot<>().title()
         );
 
         List<String> titles = dgsQueryExecutor.executeAndExtractJsonPath(graphQLQueryRequest.serialize(), "data.shows[*].title");
@@ -139,7 +139,7 @@ Now we can write a test that uses `GraphQLQueryRequest` to build the query and e
             ShowsGraphQLQuery.Builder()
                 .titleFilter("Oz")
                 .build(),
-            ShowsProjectionRoot().title())
+            ShowsProjectionRoot<Nothing, Nothing>().title())
 
         val titles = dgsQueryExecutor.executeAndExtractJsonPath<List<String>>(graphQLQueryRequest.serialize(), "data.shows[*].title")
         assertThat(titles).containsExactly("Ozark")
@@ -243,7 +243,7 @@ Let's try to mock this service in the test!
         public void showsWithQueryApi() {
             GraphQLQueryRequest graphQLQueryRequest = new GraphQLQueryRequest(
                     new ShowsGraphQLQuery.Builder().build(),
-                    new ShowsProjectionRoot().title()
+                    new ShowsProjectionRoot<>().title()
             );
 
             List<String> titles = dgsQueryExecutor.executeAndExtractJsonPath(graphQLQueryRequest.serialize(), "data.shows[*].title");


### PR DESCRIPTION
Update docs to use the v2 client API and remove references to the v1 API. 