### PR TITLE
Added missing colon in CSS variable definition in extra.css and removed duplicate css property.

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,6 +1,6 @@
 :root>* {
   --md-primary-fg-color: #e50914;
-  --md-primary-fg-color--light #e50914;
+  --md-primary-fg-color--light: #e50914;
   --md-primary-fg-color--dark: #e50914;
 }
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -67,7 +67,6 @@ code {
        word-break: keep-all;
 }
 div.td code, td code { white-space: nowrap; }
-div.td code, td code { white-space: nowrap; }
 div.marked-table div.td code, div.marked-table td code {
   word-break: keep-all;
   white-space: nowrap;


### PR DESCRIPTION
This pull request addresses a syntax error in the CSS variable definition found in `docs/stylesheets/extra.css`. A missing colon was identified, which could potentially lead to styling issues or inconsistencies across the application.
It also addresses a redundancy issue in `docs/stylesheets/extra.css` where the `white-space: nowrap;` property is duplicated for `div.td code, td code`. This redundancy could lead to confusion and makes the stylesheet harder to maintain.