### PR TITLE
fix bean configuration example

### DIFF
--- a/docs/advanced/operation-caching.md
+++ b/docs/advanced/operation-caching.md
@@ -37,8 +37,7 @@ The bean can also be injected using an annotated `@Bean` method:
 public class MyDgsConfiguration {
 
     @Bean
-    public PreparsedDocumentEntry getDocument(ExecutionInput executionInput,
-                                                     Function<ExecutionInput, PreparsedDocumentEntry> parseAndValidateFunction) {
+    public PreparsedDocumentProvider cachingPreparsedDocumentProvider() {
         return new CachingPreparsedDocumentProvider();
     }
 }


### PR DESCRIPTION
Hi!

The example of providing a PreparsedDocumentProvider by a Spring configuration bean is not correct.

Kind regards
Thomas