### PR TITLE
Fix build warnings

### DIFF
--- a/docs/advanced/file-uploads.md
+++ b/docs/advanced/file-uploads.md
@@ -15,7 +15,7 @@ dependencies {
 }
 ```
 
-If you are using the [regular DGS starter](../index.md#adding-the-dgs-framework-dependency), you don't need to do add that dependency.
+If you are using the [regular DGS starter](../index.md#adding-the-dgs-framework-dependency-with-spring-for-graphql), you don't need to do add that dependency.
 
 ## Multipart File Upload
 

--- a/docs/advanced/java-client.md
+++ b/docs/advanced/java-client.md
@@ -412,4 +412,4 @@ Errors later on in the process will be errors in the stream.
 
 Don't forget to `subscribe()` to the stream, otherwise the connection doesn't get started!
 
-An example of using the client to write subscription integration tests is available [here](../subscriptions/#integration-testing-subscriptions).
+An example of using the client to write subscription integration tests is available [here](subscriptions.md#integration-testing-subscriptions).

--- a/docs/data-loaders.md
+++ b/docs/data-loaders.md
@@ -257,7 +257,7 @@ The `v8.1.0` release introduces a new feature to [enable ticker mode](https://gi
 This allows you to schedule the dispatch checks instead of manually calling dispatch in your data loaders.
 By default, the checks will occur every 10ms but can be configured via `dgs.graphql.dataloader.scheduleDuration`.
 To enable ticker mode in the DGS framework, you can set `dgs.graphql.dataloader.ticker-mode-enabled` to true.
-In addition, you can also specify [dispatch predicates](## Scheduled Data Loaders with Dispatch Predicates) per dataloader vi a`@DgsDispatchPredicate`to better control the batching.
+In addition, you can also specify [dispatch predicates](#scheduled-data-loaders-with-dispatch-predicates) per dataloader vi a`@DgsDispatchPredicate`to better control the batching.
 
 With ticker mode enabled, you can eliminate calls to manually dispatch and rely on the scheduler to periodically check and dispatch any batches as needed.
 This should result in better batching behavior overall.

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -237,7 +237,7 @@ class ReviewssDatafetcherTest {
 }
 ```
 
-For more details on the API and how to set it up for tests, please refer to our documentation [here](./advanced/federated-testing.md#Using-the-Entities-Query-Builder-API).
+For more details on the API and how to set it up for tests, please refer to our documentation [here](./advanced/federated-testing.md#using-the-entities-query-builder-api).
 
 ## Customizing the Default Federation Resolver
 


### PR DESCRIPTION
Removes these `make build` lines:

```
INFO    -  Doc file 'advanced/java-client.md' contains an unrecognized relative link '../subscriptions/#integration-testing-subscriptions', it was left as is. Did you mean
           'subscriptions.md#integration-testing-subscriptions'?
INFO    -  Doc file 'data-loaders.md' contains a link '## Scheduled Data Loaders with Dispatch Predicates', but there is no such anchor on this page.
INFO    -  Doc file 'federation.md' contains a link './advanced/federated-testing.md#Using-the-Entities-Query-Builder-API', but the doc 'advanced/federated-testing.md' does not contain an anchor
           '#Using-the-Entities-Query-Builder-API'.
INFO    -  Doc file 'advanced/file-uploads.md' contains a link '../index.md#adding-the-dgs-framework-dependency', but the doc 'index.md' does not contain an anchor '#adding-the-dgs-framework-dependency'.
```